### PR TITLE
Stop tabgroups manager reordering tabs on startup

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+# Changes for v 1.1.0 (pre-release)
+* Fix restoring session on palemoon getting tabs in the wrong order. This ended up removing a lot of unnecessary operations, and has made reloading sessions a lot snappier. (Issue #4)
+
 # Changes for v 1.0.0
 * Added explicit palemoon support
 * Kicked min versions to 56 (basilisk), 28 (palemoon)

--- a/source/chrome/content/AllGroups.js
+++ b/source/chrome/content/AllGroups.js
@@ -96,10 +96,19 @@ TabGroupsManager.AllGroups.prototype.selectNthGroup = function(n)
   }
 };
 
+/** Get group object for specified ID
+ *
+ * @param {integer} id - the group's id
+ *
+ * @returns {GroupClass} the group object, or null if there's no group with
+ *                       that ID.
+ */
 TabGroupsManager.AllGroups.prototype.getGroupById = function(id)
 {
-  var groupTab = document.getElementById("_group" + id);
-  return groupTab ? groupTab.group : null;
+  //FIXME stored in the DOM??? At least properly mark it as user data,  or
+  //like - store it in this class as a map?
+  const groupTab = document.getElementById("_group" + id);
+  return groupTab == null ? null : groupTab.group;
 };
 
 TabGroupsManager.AllGroups.prototype.openNewGroup = function(tab, id, name, image, forTabMixPlus)
@@ -278,52 +287,20 @@ TabGroupsManager.AllGroups.prototype.endUpdateByTimer = function()
 
 TabGroupsManager.AllGroups.prototype.loadAllGroupsData = function()
 {
-  TabGroupsManager.session.groupRestored = 1;
-  try
+  const text = TabGroupsManager.session.sessionStore.getWindowValue(
+    window,
+    "TabGroupsManagerAllGroupsData");
+  if (text != "")
   {
-    try
+    const all_data = JSON.parse(text);
+    for (const data of all_data.groups)
     {
-      let jsonText = TabGroupsManager.session.sessionStore.getWindowValue(window, "TabGroupsManagerAllGroupsData");
-      if (jsonText != null && jsonText != "")
+      if (! this.getGroupById(data.id))
       {
-        var allGroupsData = JSON.parse(jsonText);
-        for (var i = 0; i < allGroupsData.groups.length; i++)
-        {
-          var groupData = allGroupsData.groups[i];
-          if (!this.getGroupById(groupData.id))
-          {
-            var group = this.openNewGroupCore(groupData.id, groupData.name, groupData.image);
-            group.setGroupDataWithoutTabs(groupData);
-          }
-        }
+        const group = this.openNewGroupCore(data.id, data.name, data.image);
+        group.setGroupDataWithoutTabs(data);
       }
     }
-    catch (e)
-    {
-      //show errors as window is not tracked during startup caused by small
-      //delay on initialisation > Fx33
-      TabGroupsManagerJsm.displayError.alertErrorIfDebug(e);
-    }
-    if (TabGroupsManager.session.sessionRestoring)
-    {
-      //Seriously, this being set seems to imply the preferences menu is open..
-      if (TabGroupsManagerJsm.globalPreferences.lastSessionFinalized)
-      {
-        //TabGroupsManager.session.allTabsMoveToGroup();
-      }
-    }
-    else
-    {
-      TabGroupsManager.allGroups.selectedGroup.initDefaultGroupAndModifyId();
-    }
-  }
-  catch (e)
-  {
-    TabGroupsManagerJsm.displayError.alertErrorIfDebug(e);
-  }
-  finally
-  {
-    TabGroupsManager.session.groupRestored = 2;
   }
 };
 

--- a/source/chrome/content/EventListener.js
+++ b/source/chrome/content/EventListener.js
@@ -97,7 +97,7 @@ TabGroupsManager.EventListener.prototype.onTabOpen = function(event)
 {
   try
   {
-    if (!TabGroupsManager.session.sessionRestoring || !TabGroupsManagerJsm.globalPreferences.lastSessionFinalized)
+    if (!TabGroupsManager.session.sessionRestoring)
     {
       var newTab = event.originalTarget;
       if (TabGroupsManager.preferences.tabTreeOpenTabByExternalApplication && TabGroupsManager.tabOpenStatus.openerContext == Ci.nsIBrowserDOMWindow.OPEN_EXTERNAL)
@@ -266,10 +266,6 @@ TabGroupsManager.EventListener.prototype.onTabMove = function(event)
 
 TabGroupsManager.EventListener.prototype.onGroupSelect = function(event)
 {
-  if (TabGroupsManager.session.allTabsMovingToGroup)
-  {
-    return;
-  }
   TabGroupsManager.eventListener.groupSelecting = true;
   try
   {

--- a/source/chrome/content/GroupClass.js
+++ b/source/chrome/content/GroupClass.js
@@ -1,7 +1,7 @@
 /*jshint browser: true, devel: true */
 /*eslint-env browser */
 
-/* globals TabGroupsManager, TabGroupsManagerJsm */
+/* globals TabGroupsManager, TabGroupsManagerJsm, gBrowser */
 
 TabGroupsManager.GroupClass = function(id, name, image)
 {
@@ -339,48 +339,29 @@ TabGroupsManager.GroupClass.prototype.addTabToTabArray = function(tab, fromSessi
 {
   try
   {
-    let [firstTab, lastTab] = this.getFirstLastTabInGroup();
+    let [ firstTab, lastTab ] = this.getFirstLastTabInGroup();
     tab.group = this;
     this.tabArray.push(tab);
     this.dispGroupLabel();
-    if (!TabGroupsManager.session.allTabsMovingToGroup)
-    {
-      //trying to work out when this makes sense. It seems to me that it only
-      //makes sense if you're trying to add a tab to a non visible group.
-      //And that doesn't seem to be necessary at all.
-      //Note it may be required with treetabs, but if so, I'll have to do it
-      //differently.
-      /*
-      if (TabGroupsManager.session.groupRestored < 2)
-      {
-        tab.tPosBak = tab._tPos;
-      }
-      else if (tab.tPosBak != null)
-      {
-        TabGroupsManager.tabMoveByTGM.moveTabTo(tab, tab.tPosBak);
-        delete tab.tPosBak;
-      }
-      else
-      {
-        //This doesn't
-        //this.moveTabToLast(tab, firstTab, lastTab);
-      }
-      */
-      this.sortTabArrayByTPos();
+    this.sortTabArrayByTPos();
 
-      switch (this.selected)
-      {
+    //FIXME Yer what? how about an if?
+    switch (this.selected)
+    {
       case false:
         TabGroupsManager.utils.hideTab(tab);
         break;
+
       default:
         TabGroupsManager.utils.unHideTab(tab);
         break;
-      }
     }
-    tab.linkedBrowser.webProgress.addProgressListener(this.progressListener, Ci.nsIWebProgress.NOTIFY_STATE_NETWORK);
+
+    tab.linkedBrowser.webProgress.addProgressListener(
+      this.progressListener,
+      Ci.nsIWebProgress.NOTIFY_STATE_NETWORK);
     this.displayGroupBusy();
-    if (!this.selectedTab)
+    if (! this.selectedTab)
     {
       this.selectedTab = tab;
       if (this.selected)
@@ -398,7 +379,7 @@ TabGroupsManager.GroupClass.prototype.addTabToTabArray = function(tab, fromSessi
     }
     if ("TreeStyleTabService" in window)
     {
-      if (!fromSessionStore)
+      if (! fromSessionStore)
       {
         if (TreeStyleTabService.hasChildTabs(tab))
         {
@@ -686,17 +667,12 @@ TabGroupsManager.GroupClass.prototype.removeTab = function(tab, fromTabCloseEven
       TabGroupsManager.allGroups.selectNextGroup();
     }
     this.unlinkTab(tab);
-    if (TabGroupsManager.session.allTabsMovingToGroup && this.id == -1)
-    {
-      this.selectedTab = null;
-    }
-    else
-    {
-      this.close();
-    }
+    this.close();
   }
   else
-  { //for startup allow select tab only if group is in status restored to prevent 2 loaded tabs in group
+  {
+    //for startup allow select tab only if group is in status restored to
+    //prevent 2 loaded tabs in group
     if (this.selectedTab == tab && TabGroupsManager.session.groupRestored == 2)
     {
       this._selectedTab = this.getNextTabWhenTabRemove(tab);
@@ -1126,33 +1102,6 @@ TabGroupsManager.GroupClass.prototype.removeAllTabsWithoutClosedTabsList = funct
   }
   this.tabArray.splice(0);
   TabGroupsManager.session.setClosedTabJson(closedTabsJson);
-};
-
-TabGroupsManager.GroupClass.prototype.initDefaultGroupAndModifyId = function()
-{
-  if (this.id == -1)
-  {
-    this.id = TabGroupsManagerJsm.applicationStatus.makeNewId();
-    for (var i = 0; i < this.tabArray.length; i++)
-    {
-      var tab = this.tabArray[i];
-      var groupId = TabGroupsManager.session.getGroupId(tab);
-      if (isNaN(groupId))
-      {
-        TabGroupsManager.session.sessionStore.setTabValue(tab, "TabGroupsManagerGroupId", this.id.toString());
-        TabGroupsManager.session.sessionStore.setTabValue(tab, "TabGroupsManagerGroupName", this.name);
-        if ("TMP_TabGroupsManager" in window)
-        {
-          TabmixSessionManager.updateTabProp(tab);
-        }
-      }
-      else
-      {
-        TabGroupsManager.session.moveTabToGroupBySessionStore(tab);
-      }
-    }
-    TabGroupsManager.allGroups.saveAllGroupsData();
-  }
 };
 
 TabGroupsManager.GroupClass.prototype.getGroupDataBase = function()

--- a/source/chrome/content/GroupClass.js
+++ b/source/chrome/content/GroupClass.js
@@ -345,6 +345,12 @@ TabGroupsManager.GroupClass.prototype.addTabToTabArray = function(tab, fromSessi
     this.dispGroupLabel();
     if (!TabGroupsManager.session.allTabsMovingToGroup)
     {
+      //trying to work out when this makes sense. It seems to me that it only
+      //makes sense if you're trying to add a tab to a non visible group.
+      //And that doesn't seem to be necessary at all.
+      //Note it may be required with treetabs, but if so, I'll have to do it
+      //differently.
+      /*
       if (TabGroupsManager.session.groupRestored < 2)
       {
         tab.tPosBak = tab._tPos;
@@ -356,8 +362,10 @@ TabGroupsManager.GroupClass.prototype.addTabToTabArray = function(tab, fromSessi
       }
       else
       {
-        this.moveTabToLast(tab, firstTab, lastTab);
+        //This doesn't
+        //this.moveTabToLast(tab, firstTab, lastTab);
       }
+      */
       this.sortTabArrayByTPos();
 
       switch (this.selected)

--- a/source/resource/modules/TabGroupsManager.jsm
+++ b/source/resource/modules/TabGroupsManager.jsm
@@ -1,5 +1,6 @@
 var EXPORTED_SYMBOLS = ["TabGroupsManagerJsm"];
 
+/* globals console */
 Components.utils.import("resource://gre/modules/Console.jsm");
 
 var TabGroupsManagerJsm = {
@@ -66,8 +67,6 @@ TabGroupsManagerJsm.GlobalPreferences = function ()
     this.prefService = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
     this.prefBranch = this.prefService.getBranch("extensions.tabgroupsmanager.");
     this.prefBranch.QueryInterface(Ci.nsIPrefBranch2);
-    this.lastSessionFinalized = !this.prefBranch.prefHasUserValue("executing");
-    this.prefBranch.setBoolPref("executing", true);
     if (this.prefBranch.prefHasUserValue("groupBarBelow"))
     {
       this.prefBranch.setIntPref("groupBarPosition", 2);
@@ -115,7 +114,6 @@ TabGroupsManagerJsm.GlobalPreferences = function ()
 
 TabGroupsManagerJsm.GlobalPreferences.prototype.finalize = function ()
 {
-  this.deletePrefValue("executing");
 };
 
 TabGroupsManagerJsm.GlobalPreferences.prototype.deletePrefValue = function (pref)
@@ -1701,6 +1699,7 @@ TabGroupsManagerJsm.QuitApplicationObserver.prototype.quitApplication = function
 {
   TabGroupsManagerJsm.finalize();
 };
+
 const Cc = Components.classes;
 const Ci = Components.interfaces;
 


### PR DESCRIPTION
This caused odd results on palemoon. Now we don't do any moving and rely on the browsers order.

This also speeds things up somewhat.

Fixes #4 